### PR TITLE
Provisioning fixes

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -41,6 +41,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provider :virtualbox do |vb, override|
   end
 
+  config.vm.provision "shell", inline: "apt-get update"
+
   config.vm.provision "docker"
 
   # kick off the tests automatically

--- a/blockade/net.py
+++ b/blockade/net.py
@@ -64,7 +64,7 @@ class BlockadeNetwork(object):
 
     def get_container_device(self, docker_client, container_id, container_name):
         try:
-            res = docker_client.execute(container_name, ['ip', 'link', 'show', 'eth0'])
+            res = docker_client.execute(container_name, ['ip', 'link', 'show', 'eth0']).decode('utf-8')
             peer_idx = int(re.search('^([0-9]+):', res).group(1))
 
             # all my experiments showed the host device index was

--- a/blockade/tests/test_integration.py
+++ b/blockade/tests/test_integration.py
@@ -171,11 +171,11 @@ class IntegrationTests(unittest.TestCase):
                 f.write(dedent('''\
                     containers:
                       zzz:
-                        image: ubuntu
+                        image: ubuntu:trusty
                         command: sleep infinity
                         expose: [10000]
                       aaa:
-                        image: ubuntu
+                        image: ubuntu:trusty
                         command: sleep infinity
                         links: ["zzz"]
                     '''))

--- a/examples/ping/blockade.yaml
+++ b/examples/ping/blockade.yaml
@@ -1,19 +1,19 @@
 containers:
   c1:
-    image: ubuntu
+    image: ubuntu:trusty
     hostname: c1
     command: /bin/sleep 30000
     # this port is unused, but we need at least one open for docker links
     expose: [10000]
 
   c2:
-    image: ubuntu
+    image: ubuntu:trusty
     hostname: c2
     command: sh -c "ping -i5 $C1_PORT_10000_TCP_ADDR"
     links: ["c1"]
 
   c3:
-    image: ubuntu
+    image: ubuntu:trusty
     hostname: c3
     command: sh -c "ping -i5 $C1_PORT_10000_TCP_ADDR"
     links: ["c1"]

--- a/examples/sleep/blockade.yaml
+++ b/examples/sleep/blockade.yaml
@@ -1,16 +1,16 @@
 containers:
   c1:
-    image: ubuntu
+    image: ubuntu:trusty
     hostname: c1
     command: sh -c 'echo "I am $HOSTNAME"; /bin/sleep 300'
     volumes: {"/tmp": "/mnt"}
 
   c2:
-    image: ubuntu
+    image: ubuntu:trusty
     hostname: c2
     command: sh -c 'echo "I am $HOSTNAME"; /bin/sleep 300'
 
   c3:
-    image: ubuntu
+    image: ubuntu:trusty
     hostname: c3
     command: sh -c 'echo "I am $HOSTNAME"; /bin/sleep 300'


### PR DESCRIPTION
I ran into some Vagrant provisioning trouble when trying to do the [tutorial](http://blockade.readthedocs.org/en/latest/guide.html) on a Mac.
With these fixes it finally worked for me, though at b28f78f I had to kick docker to fetch the image by logging in to the Vagrant box and running `docker create ...` (see commit description), so that it actually fetched the image.
